### PR TITLE
Fix for subclassing more than once from Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+lib
+coverage
+.venv
+doc/_build

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "istanbul": "^0.4.2",
     "knex": ">=0.8.6 <0.13",
     "mocha": "^3.1.0",
+    "node-uuid": "^1.4.8",
     "pg": "^6.1.0",
     "sqlite3": "^3.1.0"
   },
   "dependencies": {
     "checkit": "^0.7.0",
-    "inflection": "^1.8.0"
+    "inflection": "^1.8.0",
+    "lodash": "^4.17.4"
   },
   "peerDependencies": {
     "bookshelf": ">=0.8.2 <0.11"

--- a/src/fields.coffee
+++ b/src/fields.coffee
@@ -151,6 +151,16 @@ class EmailField extends StringField
         result.push @_withMessage 'email'
         result
 
+class UUIDField extends StringField
+    constructor: (name, options) ->
+        return new UUIDField(name, options) unless this instanceof UUIDField
+        super name, options
+
+    validations: ->
+        result = super
+        result.push @_withMessage 'uuid'
+        result
+
 class EncryptedString
     constructor: (@encrypted, @plain, @options = {}) ->
         @options.saltLength ?= 16

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -82,7 +82,7 @@ plugin = (options = {}) -> (db) ->
             else
                 -> self.apply(this, arguments)
 
-            extend child, self
+            `extend(child, self)`
             _.assign child, statics
             _.assign child.prototype, props
             self.extended? child

--- a/src/relations.coffee
+++ b/src/relations.coffee
@@ -221,7 +221,8 @@ class BelongsTo extends Relation
     contributeToSchema: (schema) ->
         super
         foreignKey = @options.foreignKey or "#{@_relatedModelName().toLowerCase()}_id"
-        pushField schema, foreignKey, IntField(foreignKey)
+        # foreign key may be integer or UUID
+        pushField schema, foreignKey, Field(foreignKey)
 
     @injectedMethods: require './relations/belongs_to'
 

--- a/test/bookshelf-schema.coffee
+++ b/test/bookshelf-schema.coffee
@@ -31,6 +31,32 @@ describe "Bookshelf schema", ->
         User.prototype.hasOwnProperty('age').should.be.true
         User.prototype.hasOwnProperty('email').should.be.true
 
+    it 'can extend from an extended model', ->
+        BaseModel = db.Model.extend {
+            constructor: ->
+                db.Model.apply this, arguments
+                this.base_property = true
+        }, {
+            schema: [
+                StringField 'commonid'
+            ]
+        }
+
+        User = BaseModel.extend {
+            tableName: 'users'
+        }, {
+            schema: [
+                StringField 'username'
+                IntField 'age'
+                EmailField 'email'
+            ]
+        }
+
+        User.__bookshelf_schema.should.be.defined
+        User.prototype.hasOwnProperty('username').should.be.true
+        user = new User
+        user.base_property.should.be.true
+
     it 'can apply schema with coffeescript @schema static method', ->
         class User extends db.Model
             tableName: 'users'

--- a/test/init.coffee
+++ b/test/init.coffee
@@ -55,6 +55,26 @@ users = co ->
         table.json 'additional_data'
         table.integer 'inviter_id'
 
+posts = co ->
+    init() unless db
+    knex = db.knex
+    yield knex.schema.dropTableIfExists 'posts'
+    yield knex.schema.createTable 'posts', (table) ->
+        table.uuid('id').primary()
+        table.dateTime 'posted_at'
+        table.dateTime 'edited_at'
+        table.string 'body', 1024
+        table.integer 'user_id'
+
+links = co ->
+    init() unless db
+    knex = db.knex
+    yield knex.schema.dropTableIfExists 'links'
+    yield knex.schema.createTable 'links', (table) ->
+        table.uuid('id').primary()
+        table.string 'url'
+        table.uuid 'post_id'
+
 photos = co ->
     init() unless db
     knex = db.knex
@@ -113,6 +133,8 @@ module.exports =
     truncate: truncate
     users: users
     photos: photos
+    posts: posts
+    links: links
     profiles: profiles
     groups: groups
     tags: tags

--- a/test/relations.coffee
+++ b/test/relations.coffee
@@ -1,10 +1,12 @@
+{result, merge} = require 'lodash'
 Bookshelf = require 'bookshelf'
+Uuid = require 'node-uuid'
 Schema = require '../src/'
 init = require './init'
 Fields = require '../src/fields'
 Relations = require '../src/relations'
 
-{StringField, IntField, EmailField} = Fields
+{StringField, IntField, EmailField, DateTimeField} = Fields
 {HasMany, BelongsTo} = Relations
 
 describe "Relations", ->
@@ -12,6 +14,8 @@ describe "Relations", ->
     db = null
     User = null
     Photo = null
+    Post = null
+    Link = null
 
     fixtures =
         alice: co ->
@@ -20,11 +24,18 @@ describe "Relations", ->
                 new Photo(filename: 'photo1.jpg', user_id: alice.id).save()
                 new Photo(filename: 'photo2.jpg', user_id: alice.id).save()
             ]
-            [alice, photos]
+            # [alice, photos]
+            pid1 = Uuid.v4()
+            post1 = yield new Post(posted_at: new Date, edited_at: new Date, body: "Frist Post", user_id: alice.id).save()
+            [alice, photos, post1]
+            pid2 = Uuid.v4()
+            post2 = yield new Post(posted_at: new Date, edited_at: new Date, body: "2nd psot", user_id: alice.id).save()
+            link = yield new Link(url: 'http://localhost', post_id: post1.id).save()
+            [alice, photos, post1, post2, link]
 
     before co ->
         db = init.init()
-        yield [ init.users(), init.photos() ]
+        yield [ init.users(), init.photos(), init.posts(), init.links() ]
 
     describe 'Common', ->
         beforeEach ->
@@ -33,20 +44,49 @@ describe "Relations", ->
 
             class User extends db.Model
                 tableName: 'users'
-                @schema [
-                    StringField 'username'
-                    HasMany Photo
-                ]
 
             Photo.schema [
                 StringField 'filename'
                 BelongsTo User
             ]
 
-        afterEach -> init.truncate 'users', 'photos'
+            class Link extends db.Model
+                tableName: 'links'
+                initialize: co ->
+                    db.Model.initialize?.call this
+                    def = result this, 'defaults'
+                    this.defaults = merge { 'id': Uuid.v4() }, def
+
+            class Post extends db.Model
+                tableName: 'posts'
+                initialize: (attributes, options) ->
+                    db.Model.initialize?.call this
+                    def = result this, 'defaults'
+                    this.defaults = merge { 'id': Uuid.v4() }, def
+                @schema [
+                    DateTimeField 'posted_at'
+                    DateTimeField 'edited_at'
+                    StringField 'body'
+                    BelongsTo User
+                    HasMany Link
+                ]
+
+            User.schema [
+                StringField 'username'
+                HasMany Photo
+                HasMany Post
+            ]
+
+            Link.schema [
+                StringField 'url'
+                BelongsTo Post
+            ]
+
+        # afterEach -> init.truncate 'users', 'photos'
+        afterEach -> init.truncate 'users', 'photos', 'posts', 'links'
 
         it 'does something relevant', co ->
-            [alice, _] = yield fixtures.alice()
+            [alice, photos, post1, post2, link] = yield fixtures.alice()
             yield alice.load('photos')
 
             alice.$photos.at(0).should.be.an.instanceof Photo
@@ -58,13 +98,22 @@ describe "Relations", ->
                     HasMany Photo, query: -> @query('where', 'filename', '=', 'photo1.jpg')
                 ]
 
-            [alice, _] = yield fixtures.alice()
+            [alice, photos, post1, post2, link] = yield fixtures.alice()
 
             yield alice.$photos.count().should.become 1
             photos = yield alice.$photos.fetch()
             photos.length.should.be.equal 1
             photos.first().should.be.an.instanceof Photo
             photos.first().filename.should.be.equal 'photo1.jpg'
+
+        it 'can relate models by uuid', co ->
+            [alice, _] = yield fixtures.alice()
+            yield alice.load('posts')
+            post = alice.$posts.first()
+            post.should.be.an.instanceof Post
+            yield post.load('links')
+            link = post.$links.first()
+            link.post_id.should.equal(post.id)
 
         it 'works with plugin registry', co ->
             db2 = Bookshelf db.knex
@@ -86,7 +135,7 @@ describe "Relations", ->
                 ]
             db2.model 'Photo', Photo
 
-            [alice, _] = yield fixtures.alice()
+            [alice, photos, post1, post2, link] = yield fixtures.alice()
 
             alice.$photos.count().should.become 2
 
@@ -107,7 +156,7 @@ describe "Relations", ->
                 BelongsTo User
             ]
 
-            [alice, _] = yield fixtures.alice()
+            [alice, photos, post1, post2, link] = yield fixtures.alice()
             yield alice.load('photos')
 
             photo = alice.rel_photos.at(0)
@@ -134,7 +183,7 @@ describe "Relations", ->
                     HasMany Photo, accessorPrefix: 'rel_'
                 ]
 
-            [alice, _] = yield fixtures.alice()
+            [alice, photos, post1, post2, link] = yield fixtures.alice()
             yield alice.load('photos')
 
             alice.rel_photos.at(0).should.be.an.instanceof Photo


### PR DESCRIPTION
Hi! We have a base class off of Bookshelf.Model, and our other models `.extend()` that. I made a small fix to allow this. I brought in lodash to make it look more like bookshelf's `extend`, but it could probably be done without if you prefer.